### PR TITLE
Fix reset helper connection name check (#28, #36)

### DIFF
--- a/built/mockgoose-helper.js
+++ b/built/mockgoose-helper.js
@@ -23,10 +23,6 @@ var MockgooseHelper = (function () {
         var _this = this;
         return new Promise(function (resolve, reject) {
             async_1.each(_this.mongoose.connections, function (connection, callback) {
-                // check if it is mockgoose connection
-                if (!/mockgoose-temp-db-/.test(connection.name)) {
-                    return callback();
-                }
                 if (connection.readyState !== 1) {
                     return callback();
                 }

--- a/src/mockgoose-helper.ts
+++ b/src/mockgoose-helper.ts
@@ -23,7 +23,8 @@ export class MockgooseHelper {
     return new Promise<void>((resolve, reject) => {
       asyncEach(this.mongoose.connections, (connection: any, callback: Function) => {
         // check if it is mockgoose connection
-        if (!/mockgoose-temp-db-/.test(connection.name)) {
+        const databaseName: string = connection.name || connection.db.databaseName;
+        if (!/mockgoose-temp-db-/.test(databaseName)) {
           return callback();
         } 
         if ( connection.readyState !== 1 ) {


### PR DESCRIPTION
This fixes an issue with newer versions of MongoDB that no longer populate `connection.name` (see #36). Issue #28 should also be resolved.