### PR TITLE
Add deprecation warning to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## Warning: This package has been deprecated! Consider using mongodb-memory-server instead.
+
 [![Build Status](https://travis-ci.org/Mockgoose/Mockgoose.svg?branch=master)](https://travis-ci.org/Mockgoose/Mockgoose)
 
 Please Share on Twitter if you like #mockgoose


### PR DESCRIPTION
Deprecation warning is hard to see on the Github page and does NOT appear on the NPM page. 
This addition makes it much more visible. Please also publish changes to NPM so that others can see the deprecation warning.